### PR TITLE
Removing pks configuration from director.yml

### DIFF
--- a/foundations/sandbox/config/director.yml
+++ b/foundations/sandbox/config/director.yml
@@ -33,17 +33,6 @@ networks-configuration:
           gateway: ((pas_subnet_gateway))
           iaas_identifier: ((network_name))/((pas_subnet_name))/((region))
           reserved_ip_ranges: ((pas_subnet_reserved_ip_ranges))
-    - name: pks
-      subnets:
-        - availability_zone_names:
-            - ((availability_zones.0))
-            - ((availability_zones.1))
-            - ((availability_zones.2))
-          cidr: ((pks_subnet_cidr))
-          dns: 168.63.129.16
-          gateway: ((pks_subnet_gateway))
-          iaas_identifier: ((network_name))/((pks_subnet_name))/((region))
-          reserved_ip_ranges: ((pks_subnet_reserved_ip_ranges))
     - name: services
       subnets:
         - availability_zone_names:


### PR DESCRIPTION
configure-director job is failing on deleted pks configuration variables. So deleting this from the director configuration file.