### PR TITLE
Add expiring-licenses job

### DIFF
--- a/pipelines/pipeline.yml
+++ b/pipelines/pipeline.yml
@@ -802,6 +802,32 @@ jobs:
         ENV_FILE: foundations/config/env.yml
         EXPIRES_WITHIN: 2m
     # code_snippet expiring-certificates-usage end
+- name: expiring-licenses
+  serial: true
+  serial_groups: [ install ]
+  plan:
+    - in_parallel:
+      - get: daily-trigger
+        trigger: true
+      - get: platform-automation-image
+        params:
+          unpack: true
+      - get: platform-automation-tasks
+        params:
+          unpack: true
+      - get: configuration
+      - get: state
+    - task: prepare-tasks-with-secrets
+      <<: *prepare-tasks-with-secrets
+    # code_snippet expiring-licenses-usage start yaml
+    - task: expiring-licenses
+      image: platform-automation-image
+      file: platform-automation-tasks/tasks/expiring-licenses.yml
+      input_mapping:
+        env: configuration
+      params:
+        ENV_FILE: foundations/config/env.yml
+    # code_snippet expiring-licenses-usage end
 - name: stage-configure-apply-telemetry
   serial_groups: [install]
   plan:


### PR DESCRIPTION
This pull request introduces a new job to the `pipelines/pipeline.yml` file for handling expiring licenses. The most important change is the addition of the `expiring-licenses` job, which includes several steps to ensure the proper execution of tasks related to expiring licenses.

### New job addition:

* [`pipelines/pipeline.yml`](diffhunk://#diff-6e85c704ce7e47ba5accdb7ad730820dd5282649cdf131592152fb222c4da3e5R805-R830): Added a new job named `expiring-licenses` with a series of steps, including fetching necessary resources, preparing tasks with secrets, and executing the `expiring-licenses` task using the `platform-automation-image`.

### DO NOT MERGE UNTIL:
- https://github.com/pivotal/docs-platform-automation/pull/87